### PR TITLE
Fix `fitted_params` and some other improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,12 @@ authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 version = "0.1.3"
 
 [deps]
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 NaiveBayes = "9bbee03b-0db5-5f46-924f-b5c9c21b8c60"
 
 [compat]
+LogExpFunctions = "0.2"
 MLJModelInterface = "0.3.5, 0.4, 1"
 NaiveBayes = "^0.5.0"
 julia = "^1.3"

--- a/src/MLJNaiveBayesInterface.jl
+++ b/src/MLJNaiveBayesInterface.jl
@@ -37,12 +37,11 @@ function MMI.fit(model::GaussianNBClassifier, verbosity::Int
 
 end
 
-function MMI.fitted_params(model::GaussianNBClassifier, fitresult)
-    res = fitresult[1]
-    return (c_counts=res.c_counts,
-            c_stats=res.c_stats,
-            gaussians=res.gaussians,
-            n_obs=res.n_obs)
+function MMI.fitted_params(::GaussianNBClassifier, fitresult)
+    return (c_counts=fitresult.c_counts,
+            c_stats=fitresult.c_stats,
+            gaussians=fitresult.gaussians,
+            n_obs=fitresult.n_obs)
 end
 
 function MMI.predict(model::GaussianNBClassifier, fitresult, Xnew)
@@ -92,12 +91,11 @@ function MMI.fit(model::MultinomialNBClassifier, verbosity::Int
     return fitresult, nothing, report
 end
 
-function MMI.fitted_params(model::MultinomialNBClassifier, fitresult)
-    res = fitresult[1]
-    return (c_counts=res.c_counts,
-            x_counts=res.x_counts,
-            x_totals=res.x_totals,
-            n_obs=res.n_obs)
+function MMI.fitted_params(::MultinomialNBClassifier, fitresult)
+    return (c_counts=fitresult.c_counts,
+            x_counts=fitresult.x_counts,
+            x_totals=fitresult.x_totals,
+            n_obs=fitresult.n_obs)
 end
 
 function MMI.predict(model::MultinomialNBClassifier, fitresult, Xnew)

--- a/src/MLJNaiveBayesInterface.jl
+++ b/src/MLJNaiveBayesInterface.jl
@@ -50,9 +50,11 @@ function MMI.predict(model::GaussianNBClassifier, fitresult, Xnew)
     classes_observed, logprobs = NaiveBayes.predict_logprobs(fitresult, convert(Matrix{Float64}, Xmatrix))
     # Note that NaiveBayes does not normalize the probabilities.
 
+    # Normalize probabilities
     for p in (view(logprobs, :, i) for i in axes(logprobs, 2))
         LogExpFunctions.softmax!(p, p)
     end
+    probs = logprobs
 
     # UnivariateFinite constructor automatically adds unobserved
     # classes with zero probability. Note we need to use adjoint here:
@@ -105,9 +107,11 @@ function MMI.predict(model::MultinomialNBClassifier, fitresult, Xnew)
     classes_observed, logprobs =
         NaiveBayes.predict_logprobs(fitresult, convert(Matrix{Int}, Xmatrix))
 
+    # Normalize probabilities
     for p in (view(logprobs, :, i) for i in axes(logprobs, 2))
         LogExpFunctions.softmax!(p, p)
     end
+    probs = logprobs
 
     return MMI.UnivariateFinite(collect(classes_observed), probs')
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,9 @@ train, test = partition(eachindex(y), 0.6)
 fitresultG, cacheG, reportG = fit(gaussian_classifier, 1,
                     selectrows(X, train), y[train]);
 
+params = fitted_params(gaussian_classifier, fitresultG)
+@test params.n_obs == length(train)
+
 gaussian_pred = predict(gaussian_classifier,
                         fitresultG,
                         selectrows(X, test));
@@ -41,6 +44,9 @@ gaussian_classifier = GaussianNBClassifier()
 
 fitresultG, cacheG, reportG = MLJBase.fit(gaussian_classifier, 1,
              selectrows(X, train), y[train])
+
+params = fitted_params(gaussian_classifier, fitresultG)
+@test params.n_obs == length(train)
 
 gaussian_pred = MLJBase.predict_mode(gaussian_classifier,
                                      fitresultG, selectrows(X, test))
@@ -96,6 +102,9 @@ multinomial_classifier = MultinomialNBClassifier()
 
 fitresultMLT, cacheMLT, reportMLT =
     MLJBase.fit(multinomial_classifier, 1, X, y)
+
+params = fitted_params(multinomial_classifier, fitresultMLT)
+@test params.n_obs == length(y) + 3 * 2 # 3 features, 2 classes
 
 yhat = MLJBase.predict(multinomial_classifier, fitresultMLT, Xnew)
 


### PR DESCRIPTION
Currently `fitted_params` throws an error since `fitresult[1]` fails.

I took the opportunity to also improve type stability and increase numerical stability. However, these changes are all in separate commits so it would be easy to split the PR if desired.