### PR TITLE
Support LogExpFunctions 0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJNaiveBayesInterface"
 uuid = "33e4bacb-b9e2-458e-9a13-5d9a90b235fa"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
@@ -9,7 +9,7 @@ MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 NaiveBayes = "9bbee03b-0db5-5f46-924f-b5c9c21b8c60"
 
 [compat]
-LogExpFunctions = "0.2"
+LogExpFunctions = "0.2, 0.3"
 MLJModelInterface = "0.3.5, 0.4, 1"
 NaiveBayes = "^0.5.0"
 julia = "^1.3"


### PR DESCRIPTION
It seems currently MLJNaiveBayesInterface doesn't support LogExpFunctions 0.3. This package uses only `LogExpFunctions.softmax!` which was not affected by the breaking changes in 0.3.0 (https://github.com/JuliaStats/LogExpFunctions.jl/releases/tag/v0.3.0).